### PR TITLE
チェック処理の追加による高速化

### DIFF
--- a/ReplaceHttp.nim
+++ b/ReplaceHttp.nim
@@ -62,13 +62,14 @@ proc load_dict_dir*(dict_path = "./dicts/"): seq[DictData] =
 proc engtokana(text: string): string {.gcsafe.} =
   var tmp_text = text
 
-  var matchs:seq[DictData]
+  var replace_arr :seq[DictData]
   {.gcsafe.}:
     for dic in dict:
-      if(text.match(dic.from_re)): matchs.add(dic)
+      if(text.contains(dic.from_re)):
+        replace_arr.add(dic)
       #tmp_text = tmp_text.replace(dic.from_re, dic.to)
 
-    for m in matchs:
+    for m in replace_arr:
       tmp_text = tmp_text.replace(m.from_re, m.to)
 
   result = tmp_text
@@ -85,7 +86,7 @@ proc onRequest*(ctx: Context): Future[void] {.async, gcsafe.} =
     resp "error", Http400
 
 proc main() {.async.} =
-  echo "start"
+  echo "starting..."
   dict = load_dict_dir()
   echo "dict loaded"
 

--- a/ReplaceHttp.nim
+++ b/ReplaceHttp.nim
@@ -61,9 +61,15 @@ proc load_dict_dir*(dict_path = "./dicts/"): seq[DictData] =
 
 proc engtokana(text: string): string {.gcsafe.} =
   var tmp_text = text
+
+  var matchs:seq[DictData]
   {.gcsafe.}:
     for dic in dict:
-      tmp_text = tmp_text.replace(dic.from_re, dic.to)
+      if(text.match(dic.from_re)): matchs.add(dic)
+      #tmp_text = tmp_text.replace(dic.from_re, dic.to)
+
+    for m in matchs:
+      tmp_text = tmp_text.replace(m.from_re, m.to)
 
   result = tmp_text
 

--- a/ReplaceHttp.nim
+++ b/ReplaceHttp.nim
@@ -62,12 +62,11 @@ proc load_dict_dir*(dict_path = "./dicts/"): seq[DictData] =
 proc engtokana(text: string): string {.gcsafe.} =
   var tmp_text = text
 
-  var replace_arr :seq[DictData]
+  var replace_arr: seq[DictData]
   {.gcsafe.}:
     for dic in dict:
       if(text.contains(dic.from_re)):
         replace_arr.add(dic)
-      #tmp_text = tmp_text.replace(dic.from_re, dic.to)
 
     for m in replace_arr:
       tmp_text = tmp_text.replace(m.from_re, m.to)

--- a/ReplaceHttp.nim
+++ b/ReplaceHttp.nim
@@ -62,14 +62,10 @@ proc load_dict_dir*(dict_path = "./dicts/"): seq[DictData] =
 proc engtokana(text: string): string {.gcsafe.} =
   var tmp_text = text
 
-  var replace_arr: seq[DictData]
   {.gcsafe.}:
     for dic in dict:
-      if(text.contains(dic.from_re)):
-        replace_arr.add(dic)
-
-    for m in replace_arr:
-      tmp_text = tmp_text.replace(m.from_re, m.to)
+      if(tmp_text.contains(dic.from_re)):
+        tmp_text = tmp_text.replace(dic.from_re, dic.to)
 
   result = tmp_text
 


### PR DESCRIPTION
replace処理が思ったより重いので先にcontainsで対象があるかチェックして対象だけ置換するように。
配列に隔離するパターンと比べて日本語が0~3ms前後遅くなったりするけど、英語が5msほど安定して速い傾向があったので直接置換するように。

非同期化も試したけど辞書の読み込みエラーが起きる場合がある割に5万件程度じゃ3ms前後速くなるときがある程度だったのでやってない。

マルチスレッド化すれば速いかもしれないけど、この段階でも元の処理と比べれば1.5~2倍ぐらい速くなってるのでこれで妥協する。

ついでに起動時のメッセージをいい感じに。

以下参考記録

### Original 
https://github.com/notoiro/replace_http

普通にforでReplaceしてる     
辞書の処理が間違ってる可能性があるが、面倒なので検証してない

#### 日本語
remote replace time: 52.661ms     

#### 英語
remote replace time: 67.865ms     

### Test Patterns
https://github.com/notoiro/replace_http/tree/p_test

最初にパターンに当てはまるものをチェックして当てはまるものだけ置換処理を再ループ

#### 日本語
remote replace time: 24.361ms　　　　　

#### 英語
remote replace time: 22.304ms

### async test
https://github.com/notoiro/replace_http/tree/p_test2

初期化処理時に適当な数で配列を分割、置換処理時に当てはまるものを非同期でチェック、当てはまるものだけ置換処理を再ループ

#### 500
remote replace time: 25.302ms
remote replace time: 28.71ms

#### 1000
remote replace time: 24.377ms
remote replace time: 23.517ms

#### 2000
remote replace time: 23.038ms
remote replace time: 31.884ms

#### 5000
remote replace time: 21.361ms
remote replace time: 28.175ms